### PR TITLE
add-npm-publish-github-actions

### DIFF
--- a/.github/workflows/publish-hybrid.yml
+++ b/.github/workflows/publish-hybrid.yml
@@ -1,10 +1,11 @@
 name: Publish to npm (monorepo or solo)
 
-on:
-  push:
-    branches:
-      - main
-      - dev
+# TODO: Fix issues, add changed packages checker
+# on:
+#   push:
+#     branches:
+#       - main
+#       - dev
 
 jobs:
   publish:

--- a/.github/workflows/publish-hybrid.yml
+++ b/.github/workflows/publish-hybrid.yml
@@ -1,0 +1,92 @@
+name: Publish to npm (monorepo or solo)
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node (v20 LTS)
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (if using turborepo)
+        run: |
+          if [ -f turbo.json ]; then
+            npx turbo run build
+          elif [ -f package.json ]; then
+            npm run build || echo "No build script, skipping"
+          fi
+
+      - name: Detect monorepo or solo
+        id: detect
+        run: |
+          if [ -d packages ]; then
+            echo "mode=monorepo" >> $GITHUB_OUTPUT
+          else
+            echo "mode=solo" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+          MODE="${{ steps.detect.outputs.mode }}"
+
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+          if [ "$MODE" = "monorepo" ]; then
+            for pkgPath in packages/*; do
+              if [ -f "$pkgPath/package.json" ]; then
+                echo "Publishing $pkgPath..."
+
+                cd "$pkgPath"
+                if [ "$BRANCH_NAME" = "main" ]; then
+                  npm version patch --no-git-tag-version
+                  npm publish
+                elif [ "$BRANCH_NAME" = "dev" ]; then
+                  npm version prerelease --preid=beta --no-git-tag-version
+                  npm publish --tag beta
+                fi
+                VERSION=$(node -p "require('./package.json').version")
+                PKG_NAME=$(node -p "require('./package.json').name" | sed 's/@//;s/\//-/g')
+
+                cd -
+
+                git add "$pkgPath/package.json"
+                git commit -m "chore(release): $PKG_NAME@v$VERSION"
+                git tag "$PKG_NAME@v$VERSION"
+                git push origin "$PKG_NAME@v$VERSION"
+              fi
+            done
+          else
+            echo "Publishing solo repo..."
+
+            if [ "$BRANCH_NAME" = "main" ]; then
+              npm version patch --no-git-tag-version
+              npm publish
+            elif [ "$BRANCH_NAME" = "dev" ]; then
+              npm version prerelease --preid=beta --no-git-tag-version
+              npm publish --tag beta
+            fi
+
+            VERSION=$(node -p "require('./package.json').version")
+            git add package.json package-lock.json
+            git commit -m "chore(release): v$VERSION"
+            git tag "v$VERSION"
+            git push origin "v$VERSION"
+          fi

--- a/.github/workflows/publish-hybrid.yml
+++ b/.github/workflows/publish-hybrid.yml
@@ -73,7 +73,8 @@ jobs:
                 git push origin "$PKG_NAME@v$VERSION"
               fi
             done
-          else
+
+          elif [ "$MODE" = "solo" ]; then
             echo "Publishing solo repo..."
 
             if [ "$BRANCH_NAME" = "main" ]; then
@@ -89,4 +90,8 @@ jobs:
             git commit -m "chore(release): v$VERSION"
             git tag "v$VERSION"
             git push origin "v$VERSION"
+
+          else
+            echo "❌ Error: Could not detect repo type (monorepo or solo)."
+            exit 1
           fi

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,57 @@
+name: Publish Monorepo Packages
+
+# on:
+#   push:
+#     branches:
+#       - main
+#       - dev
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node (v20 LTS)
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: npx turbo run build
+
+      - name: Find changed packages
+        id: changed
+        run: |
+          echo "CHANGED_PACKAGES=$(npx turbo run build --dry=json | jq -r '.tasks[].package')" >> $GITHUB_ENV
+
+      - name: Publish changed packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+          for pkg in $CHANGED_PACKAGES; do
+            echo "Publishing $pkg..."
+            cd packages/$pkg
+            if [ "$BRANCH_NAME" = "main" ]; then
+              npm version patch --no-git-tag-version
+              npm publish
+            elif [ "$BRANCH_NAME" = "dev" ]; then
+              npm version prerelease --preid=beta --no-git-tag-version
+              npm publish --tag beta
+            fi
+            VERSION=$(node -p "require('./package.json').version")
+            cd ../..
+
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git add packages/$pkg/package.json
+            git commit -m "chore(release): $pkg@v$VERSION"
+            git tag $pkg@v$VERSION
+            git push origin $pkg@v$VERSION
+          done

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,10 +1,10 @@
 name: Publish Monorepo Packages
 
-# on:
-#   push:
-#     branches:
-#       - main
-#       - dev
+on:
+  push:
+    branches:
+      - main
+      - dev
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish Package to npm
+
+# on:
+#   push:
+#     branches:
+#       - main
+#       - dev
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node (v20 LTS)
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Bump version (main or dev)
+        id: bump
+        run: |
+          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+          if [ "$BRANCH_NAME" = "main" ]; then
+            npm version patch --no-git-tag-version
+          elif [ "$BRANCH_NAME" = "dev" ]; then
+            npm version prerelease --preid=beta --no-git-tag-version
+          fi
+          echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
+      - name: Publish to npm
+        run: |
+          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+          if [ "$BRANCH_NAME" = "main" ]; then
+            npm publish
+          elif [ "$BRANCH_NAME" = "dev" ]; then
+            npm publish --tag beta
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create Git tag
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add package.json package-lock.json
+          git commit -m "chore(release): v$VERSION"
+          git tag v$VERSION
+          git push origin v$VERSION


### PR DESCRIPTION
- Added a unified GitHub Actions workflow (publish-hybrid.yml) for npm publishing supporting both monorepo and solo package setups on main and dev branches.
- The new workflow detects repository type, runs appropriate build commands, bumps versions, publishes packages with correct tags, and commits version bumps with tags for release tracking.
- Improved repo type detection with explicit error handling to prevent silent failures and clarify publishing modes.
- Disabled the publish-hybrid workflow trigger temporarily due to issues; enabled the publish-packages workflow trigger on main and dev branches for monorepo package publishing.