### PR TITLE
ci: enhance publish workflow to include package paths

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -30,19 +30,39 @@ jobs:
       - name: Build packages
         run: pnpm turbo run build
 
-      - name: Find changed packages
+      - name: Find changed packages and paths
         id: changed
         run: |
-          echo "CHANGED_PACKAGES=$(pnpm turbo run build --dry=json | jq -r '.tasks[].package')" >> $GITHUB_ENV
+          # Get changed package names
+          CHANGED_NAMES=$(pnpm turbo run build --dry=json | jq -r '.tasks[].package')
+
+          # Get full workspace metadata
+          pnpm m ls --json > workspace.json
+
+          # Map names to paths
+          echo "changed_list=" >> $GITHUB_OUTPUT
+          for pkg in $CHANGED_NAMES; do
+            path=$(jq -r --arg name "$pkg" '.[] | select(.name==$name) | .path' workspace.json)
+            if [ -n "$path" ]; then
+              echo "$pkg:$path" >> changed.txt
+            fi
+          done
+
+          # Save comma-separated list like @pkg/name:packages/real-path
+          CHANGED_LIST=$(paste -sd "," changed.txt)
+          echo "changed_list=$CHANGED_LIST" >> $GITHUB_OUTPUT
 
       - name: Publish changed packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
-          for pkg in $CHANGED_PACKAGES; do
-            echo "Publishing $pkg..."
-            cd packages/$pkg
+          IFS=',' read -ra ENTRIES <<< "${{ steps.changed.outputs.changed_list }}"
+          for entry in "${ENTRIES[@]}"; do
+            IFS=':' read -r NAME PATH <<< "$entry"
+            echo "Publishing $NAME at $PATH..."
+            cd "$PATH"
+
             if [ "$BRANCH_NAME" = "main" ]; then
               pnpm version patch --no-git-tag-version
               pnpm publish
@@ -50,13 +70,14 @@ jobs:
               pnpm version prerelease --preid=beta --no-git-tag-version
               pnpm publish --tag beta
             fi
+
             VERSION=$(node -p "require('./package.json').version")
             cd ../..
 
             git config user.name "github-actions"
             git config user.email "github-actions@github.com"
-            git add packages/$pkg/package.json
-            git commit -m "chore(release): $pkg@v$VERSION"
-            git tag $pkg@v$VERSION
-            git push origin $pkg@v$VERSION
+            git add "$PATH/package.json"
+            git commit -m "chore(release): $NAME@v$VERSION"
+            git tag "$NAME@v$VERSION"
+            git push origin "$NAME@v$VERSION"
           done


### PR DESCRIPTION
Update the publish-packages workflow to retrieve changed package paths
alongside their names. This allows publishing scripts to navigate to the
correct directories instead of assuming a fixed path structure. The change
improves accuracy when handling packages located outside the default
packages/ directory. It also updates git commands to use the resolved paths
for committing and tagging, ensuring correct version control operations.