### PR TITLE
ci: add release workflow and disable publish on push

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,10 +1,10 @@
 name: Publish Monorepo Packages
 
-on:
-  push:
-    branches:
-      - main
-      - dev
+# on:
+#   push:
+#     branches:
+#       - main
+#       - dev
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4.0.0
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install
+        # env:
+        #   GITHUB_TOKEN: ${{ secrets.ZERO_READONLY_GITHUB_TOKEN_V1 }}
+        #   NPM_TOKEN: ${{ secrets.ZERO_READONLY_NPM_TOKEN_V1 }}
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # Note: pnpm install after versioning is necessary to refresh lockfile
+          version: pnpm run version
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: pnpm run release
+          commit: '[ci] Release packages'
+          title: '[ci] Release packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.ZEROOPENSOURCE_GITHUB_AUTOMATION_NPM_TOKEN_V1 }}


### PR DESCRIPTION
Add a new GitHub Actions workflow to automate releases on pushes
to the main branch. The release workflow checks out the repo,
sets up Node.js 20 and pnpm, installs dependencies, and runs
versioning and publishing steps using changes.

Disable the publish-packages workflow triggers to avoid
conflicts and duplicate publishing processes. This change improves
release automation and streamlines package publishing.