### PR TITLE
chore(zero-schema): remove private flag from package.json

### DIFF
--- a/packages/zero-schema/package.json
+++ b/packages/zero-schema/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@zeroopensource/zero-schema",
   "version": "0.0.1",
-  "private": true,
   "scripts": {
     "build:sqlite": "ts-node src/schemix/build-sqlite.ts",
     "build:postgresql": "ts-node src/schemix/build-postgresql.ts",


### PR DESCRIPTION
Remove the "private": true field from the package.json of the zero-schema
package to allow publishing it to the npm registry. This change enables
distribution and sharing of the package as part of the zeroopensource
project.