### PR TITLE
chore(package): add files and publishConfig to package.json

### DIFF
--- a/packages/zero-schema/package.json
+++ b/packages/zero-schema/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@zeroopensource/zero-schema",
   "version": "0.0.1",
+  "files": [
+    "dist/**",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build:sqlite": "ts-node src/schemix/build-sqlite.ts",
     "build:postgresql": "ts-node src/schemix/build-postgresql.ts",


### PR DESCRIPTION
- Added "files" field in package.json to restrict published files to dist and LICENSE.
- Added "publishConfig" with public access to enable public package publishing.
- Prepared the package for proper distribution on npm.