### PR TITLE
feat(blogpost): add subTitle field to BlogPostV1 model

### DIFF
--- a/packages/zero-schema/src/schemix/models/BlogPostV1.model.ts
+++ b/packages/zero-schema/src/schemix/models/BlogPostV1.model.ts
@@ -13,6 +13,7 @@ export default createModel(BlogPostV1Model => {
     .dateTime('publishedDate', { optional: true })
     .dateTime('lastModifiedDate', { optional: true })
     .string('title')
+    .string('subTitle')
     .string('content')
     .string('excerpt', { optional: true })
     .boolean('isPublished', { default: false })


### PR DESCRIPTION
- Added a new optional string field `subTitle` to the BlogPostV1 model  
- Enabled support for an additional title attribute to enhance content representation  
- Improved flexibility for blog post metadata through this change