### PR TITLE
feat(zero-schema): add MIT license and rename tags field

### DIFF
--- a/.changeset/wet-eagles-drop.md
+++ b/.changeset/wet-eagles-drop.md
@@ -1,0 +1,5 @@
+---
+"@zeroopensource/zero-schema": patch
+---
+
+feat(zero-schema): add MIT license and rename tags field

--- a/packages/zero-schema/LICENSE
+++ b/packages/zero-schema/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Zero Open Source™ (aka ZeroOpenSource™; “Zero”)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/zero-schema/src/schemix/models/BlogPostV1.model.ts
+++ b/packages/zero-schema/src/schemix/models/BlogPostV1.model.ts
@@ -14,7 +14,7 @@ export default createModel(BlogPostV1Model => {
     .dateTime('lastModifiedDate', { optional: true })
     .string('title')
     .string('subTitle')
-    .string('tags')
+    .string('tags2')
     .string('content')
     .string('excerpt', { optional: true })
     .boolean('isPublished', { default: false })


### PR DESCRIPTION
- Added an MIT license file to clarify the package's open source terms.  
- Renamed the 'tags' field to 'tags2' in the BlogPostV1 model to avoid naming conflicts or prepare for schema evolution.